### PR TITLE
Use archived version of indonesia doc that now 404s

### DIFF
--- a/src/content/indices/indonesia.mdx
+++ b/src/content/indices/indonesia.mdx
@@ -51,9 +51,9 @@ Based on the breakpoint values in the table above a piecewise linear function is
 
 ## References
 
-[^1]: [https://ditppu.menlhk.go.id/portal/read/indeks-standar-pencemar-udara-ispu-sebagai-informasi-mutu-udara-ambien-di-indonesia](https://ditppu.menlhk.go.id/portal/read/indeks-standar-pencemar-udara-ispu-sebagai-informasi-mutu-udara-ambien-di-indonesia)
+[^1]: [https://ditppu.menlhk.go.id/portal/read/indeks-standar-pencemar-udara-ispu-sebagai-informasi-mutu-udara-ambien-di-indonesia](https://web.archive.org/web/20210618014532/https://ditppu.menlhk.go.id/portal/read/indeks-standar-pencemar-udara-ispu-sebagai-informasi-mutu-udara-ambien-di-indonesia)
 
-"INDEKS STANDAR PENCEMAR UDARA (ISPU) SEBAGAI INFORMASI MUTU UDARA AMBIEN DI INDONESIA." Kementerian Lingkungan Hidup dan Kehutanan, 24 Sept. 2020, [ditppu.menlhk.go.id/portal/read/indeks-standar-pencemar-udara-ispu-sebagai-informasi-mutu-udara-ambien-di-indonesia](https://ditppu.menlhk.go.id/portal/read/indeks-standar-pencemar-udara-ispu-sebagai-informasi-mutu-udara-ambien-di-indonesia).
+"INDEKS STANDAR PENCEMAR UDARA (ISPU) SEBAGAI INFORMASI MUTU UDARA AMBIEN DI INDONESIA." Kementerian Lingkungan Hidup dan Kehutanan, 24 Sept. 2020, [ditppu.menlhk.go.id/portal/read/indeks-standar-pencemar-udara-ispu-sebagai-informasi-mutu-udara-ambien-di-indonesia](https://web.archive.org/web/20210618014532/https://ditppu.menlhk.go.id/portal/read/indeks-standar-pencemar-udara-ispu-sebagai-informasi-mutu-udara-ambien-di-indonesia).
 
 "Keputusan Menteri Negara Lingkungan Hidup No. 45 Tahun 1997. Tentang : Indeks Standar Pencemar Udara." 1997, [ppkl.menlhk.go.id/website/filebox/770/190930181350KEPMENH-45%20TAHUN%201997.pdf](https://ppkl.menlhk.go.id/website/filebox/770/190930181350KEPMENH-45%20TAHUN%201997.pdf).
 


### PR DESCRIPTION
While reading through Indonesia docs I noticed these were 404-ing; I've replaced the links with a link to archive.orgs version of the page from roughly the time period it was originally accessed. (No earlier versions are available). 