### PR TITLE
Add Guatemala ICA index documentation and breakpoints

### DIFF
--- a/src/content/indices/guatemala.mdx
+++ b/src/content/indices/guatemala.mdx
@@ -1,0 +1,91 @@
+---
+name: Guatemala
+indexName: Índice de Calidad del Aire
+indexAcronym: ICA
+---
+
+import ColorScale from "@components/ColorScale.astro";
+import BreakpointsTable from "@components/BreakpointsTable.astro";
+import PiecewiseLatexDoc from "@components/PiecewiseLatexDoc.astro";
+import { AqiCalculator } from "@components/AqiCalculator.tsx";
+
+## Background
+
+The Instituto Nacional de Sismología, Vulcanología, Meteorología e Hidrología
+(INSIVUMEH) reports air quality in Guatemala using the Índice de Calidad del
+Aire (ICA)[^1]. The ICA accounts for pollutant concentrations of
+PM<sub>2.5</sub>, PM<sub>10</sub>, O<sub>3</sub>, CO, SO<sub>2</sub> and
+NO<sub>2</sub>, and follows the methodology of the United States Environmental
+Protection Agency (EPA) as described in the 2018 Technical Assistance Document
+for the Reporting of Daily Air Quality (EPA-454/B-18-007)[^2].
+
+The ICA ranges from 0 to 500. Unlike the United States AQI on which it is
+based, the ICA uses a single "Peligrosa" (Hazardous) category covering index
+values from 301 to 500.
+
+## Color scale
+
+The ICA uses a six-level color scale with the following categories: Buena
+(Good), Moderada (Moderate), Dañina a la salud para grupos sensibles (Unhealthy
+for Sensitive Groups), Dañina a la salud (Unhealthy), Muy dañina a la salud
+(Very Unhealthy) and Peligrosa (Hazardous)[^1]:
+
+<ColorScale index="guatemala" value={true} />
+
+_Note_: Adapted from "Boletines de Calidad del Aire" (n.d.),
+[https://insivumeh.gob.gt/boletines-de-calidad-del-aire/](https://insivumeh.gob.gt/boletines-de-calidad-del-aire/)
+[^1]. Accessed 12 Aug. 2026.
+
+## Methods
+
+<BreakpointsTable index="guatemala" />
+
+_Note_: Adapted from "Technical Assistance Document for the Reporting of Daily
+Air Quality – the Air Quality Index (AQI)" (Sept. 2018),
+[https://insivumeh.gob.gt/wp-content/uploads/2026/03/aqi-technical-assistance-document-sept2018.pdf](https://insivumeh.gob.gt/wp-content/uploads/2026/03/aqi-technical-assistance-document-sept2018.pdf)
+[^2]. Accessed 12 Aug. 2026.
+
+Based on the breakpoint values in the table above, a piecewise linear function
+is used to convert the concentration values to ICA values. The function is
+defined as:
+
+<div class="latex-container">
+
+<PiecewiseLatexDoc label="ICA" />
+
+</div>
+
+<AqiCalculator
+  client:only="solid"
+  index="guatemala"
+  acronym={frontmatter.indexAcronym}
+/>
+
+Following the EPA methodology, 8-hour O<sub>3</sub> values do not define index
+values of 301 or higher; such values are calculated using 1-hour
+O<sub>3</sub> concentrations. 1-hour SO<sub>2</sub> values do not define index
+values of 200 or higher; such values are calculated using 24-hour
+SO<sub>2</sub> concentrations[^2].
+
+The ICA uses sub-indices assigned to each of the measured pollutants. The
+highest sub-index determines the overall ICA value.
+
+<div class="latex-container">
+$$
+{ICA} = {Max}({I}_{PM_{10}},{I}_{PM_{2.5}},{I}_{SO_{2}},{I}_{NO_{2}},{I}_{O_{3}},{I}_{CO})
+$$
+</div>
+
+## References
+
+"Boletines de Calidad del Aire." Instituto Nacional de Sismología,
+Vulcanología, Meteorología e Hidrología,
+[insivumeh.gob.gt/boletines-de-calidad-del-aire/](https://insivumeh.gob.gt/boletines-de-calidad-del-aire/).
+
+"Technical Assistance Document for the Reporting of Daily Air Quality – the
+Air Quality Index (AQI)." U.S. Environmental Protection Agency, Sept. 2018,
+[insivumeh.gob.gt/wp-content/uploads/2026/03/aqi-technical-assistance-document-sept2018.pdf](https://insivumeh.gob.gt/wp-content/uploads/2026/03/aqi-technical-assistance-document-sept2018.pdf).
+
+[^1]: "Boletines de Calidad del Aire." Instituto Nacional de Sismología, Vulcanología, Meteorología e Hidrología, [insivumeh.gob.gt/boletines-de-calidad-del-aire/](https://insivumeh.gob.gt/boletines-de-calidad-del-aire/).
+
+[^2]: "Technical Assistance Document for the Reporting of Daily Air Quality – the Air Quality Index (AQI)." U.S. Environmental Protection Agency, Sept. 2018, [insivumeh.gob.gt/wp-content/uploads/2026/03/aqi-technical-assistance-document-sept2018.pdf](https://insivumeh.gob.gt/wp-content/uploads/2026/03/aqi-technical-assistance-document-sept2018.pdf).

--- a/src/data/breakpoints/guatemala.csv
+++ b/src/data/breakpoints/guatemala.csv
@@ -1,0 +1,43 @@
+ISO,variant,category,hex,category_lower,category_upper,pollutant,units,averaging_period,concentration_lower,concentration_upper
+GT,,Good,#00e400,0,50,PM2.5,ug/m3,24,0,12
+GT,,Good,#00e400,0,50,PM10,ug/m3,24,0,54
+GT,,Good,#00e400,0,50,CO,ppm,8,0,4.4
+GT,,Good,#00e400,0,50,O3,ppm,1,,
+GT,,Good,#00e400,0,50,O3,ppm,8,0,0.054
+GT,,Good,#00e400,0,50,SO2,ppb,1,0,35
+GT,,Good,#00e400,0,50,NO2,ppb,1,0,53
+GT,,Moderate,#ffff00,51,100,PM2.5,ug/m3,24,12.1,35.4
+GT,,Moderate,#ffff00,51,100,PM10,ug/m3,24,55,154
+GT,,Moderate,#ffff00,51,100,CO,ppm,8,4.5,9.4
+GT,,Moderate,#ffff00,51,100,O3,ppm,1,,
+GT,,Moderate,#ffff00,51,100,O3,ppm,8,0.055,0.07
+GT,,Moderate,#ffff00,51,100,SO2,ppb,1,36,75
+GT,,Moderate,#ffff00,51,100,NO2,ppb,1,54,100
+GT,,Unhealthy for Sensitive Groups,#ff7e00,101,150,PM2.5,ug/m3,24,35.5,55.4
+GT,,Unhealthy for Sensitive Groups,#ff7e00,101,150,PM10,ug/m3,24,155,254
+GT,,Unhealthy for Sensitive Groups,#ff7e00,101,150,CO,ppm,8,9.5,12.4
+GT,,Unhealthy for Sensitive Groups,#ff7e00,101,150,O3,ppm,1,0.125,0.164
+GT,,Unhealthy for Sensitive Groups,#ff7e00,101,150,O3,ppm,8,0.071,0.085
+GT,,Unhealthy for Sensitive Groups,#ff7e00,101,150,SO2,ppb,1,76,185
+GT,,Unhealthy for Sensitive Groups,#ff7e00,101,150,NO2,ppb,1,101,360
+GT,,Unhealthy,#ff0000,151,200,PM2.5,ug/m3,24,55.5,150.4
+GT,,Unhealthy,#ff0000,151,200,PM10,ug/m3,24,255,354
+GT,,Unhealthy,#ff0000,151,200,CO,ppm,8,12.5,15.4
+GT,,Unhealthy,#ff0000,151,200,O3,ppm,1,0.165,0.204
+GT,,Unhealthy,#ff0000,151,200,O3,ppm,8,0.086,0.105
+GT,,Unhealthy,#ff0000,151,200,SO2,ppb,1,186,304
+GT,,Unhealthy,#ff0000,151,200,NO2,ppb,1,361,649
+GT,,Very Unhealthy,#8f3f97,201,300,PM2.5,ug/m3,24,150.5,250.4
+GT,,Very Unhealthy,#8f3f97,201,300,PM10,ug/m3,24,355,424
+GT,,Very Unhealthy,#8f3f97,201,300,CO,ppm,8,15.5,30.4
+GT,,Very Unhealthy,#8f3f97,201,300,O3,ppm,1,0.205,0.404
+GT,,Very Unhealthy,#8f3f97,201,300,O3,ppm,8,0.106,0.2
+GT,,Very Unhealthy,#8f3f97,201,300,SO2,ppb,1,305,604
+GT,,Very Unhealthy,#8f3f97,201,300,NO2,ppb,1,650,1249
+GT,,Hazardous,#7e0023,301,500,PM2.5,ug/m3,24,250.5,500.4
+GT,,Hazardous,#7e0023,301,500,PM10,ug/m3,24,425,604
+GT,,Hazardous,#7e0023,301,500,CO,ppm,8,30.5,50.4
+GT,,Hazardous,#7e0023,301,500,O3,ppm,1,0.405,0.604
+GT,,Hazardous,#7e0023,301,500,O3,ppm,8,,
+GT,,Hazardous,#7e0023,301,500,SO2,ppb,1,605,1004
+GT,,Hazardous,#7e0023,301,500,NO2,ppb,1,1250,2049


### PR DESCRIPTION
Closes #87

## Summary

Adds Guatemala's Índice de Calidad del Aire (ICA), reported by INSIVUMEH.

As noted in the issue, the ICA follows the US EPA methodology — INSIVUMEH's [bulletins page](https://insivumeh.gob.gt/boletines-de-calidad-del-aire/) cites EPA-454/B-18-007 and hosts the EPA's Sept. 2018 Technical Assistance Document, so the breakpoints are the pre-2024 US values. The one structural difference: the ICA uses a single **Peligrosa (Hazardous)** category spanning index values 301–500, where the US AQI splits that range into two tiers. The merged Hazardous concentration ranges therefore take the lower bound of the US 301–400 row and the upper bound of the 401–500 row.

Category names and the 0–500 scale were confirmed against INSIVUMEH's published category graphic (Buena, Moderada, Dañina a la salud para grupos sensibles, Dañina a la salud, Muy dañina a la salud, Peligrosa).

## Judgment calls for review

- **Hex colors:** INSIVUMEH publishes no official hex values (their graphic is a JPEG of what appears to be the standard EPA palette), so the CSV uses the EPA-standard hex codes.
- **SO2 averaging period:** listed as 1-hour throughout the CSV, with the EPA rule that index values ≥ 200 are calculated from 24-hour concentrations explained in prose — matching how `us.csv` handles it.
- **Blank cells:** O3 1-hour is left undefined below the sensitive-groups category, and O3 8-hour is left undefined in Hazardous per footnote 2 of the EPA document (8-hour values do not define AQI ≥ 301).

## Verification

- Rendered locally: color scale, breakpoints table, and calculator all populate correctly.
- All 42 CSV rows programmatically checked against an independent transcription of EPA Table 5, including continuity between adjacent categories (no gaps/overlaps).
- The EPA document's worked example (8-hr O3 0.078 → AQI 126) reproduces exactly with these breakpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)